### PR TITLE
feat: CQDG-98 Update User model to have a list of research areas 

### DIFF
--- a/migrations/1676914790527_update-research-area-to-be-a-list.sql
+++ b/migrations/1676914790527_update-research-area-to-be-a-list.sql
@@ -1,0 +1,13 @@
+-- Up Migration
+ALTER TABLE users
+    ADD COLUMN research_areas TEXT[];
+
+ALTER TABLE users
+    RENAME COLUMN research_area TO research_area_description;
+
+-- Down Migration
+ALTER TABLE users
+    DROP COLUMN research_areas TEXT[];
+
+ALTER TABLE users
+    RENAME COLUMN research_area_description TO research_area;

--- a/src/db/models/User.ts
+++ b/src/db/models/User.ts
@@ -15,7 +15,8 @@ interface IUserAttributes {
     roles?: string[];
     affiliation?: string;
     portal_usages?: string[];
-    research_area?: string;
+    research_areas?: string[];
+    research_area_description?: string;
     creation_date: Date;
     updated_date: Date;
     consent_date?: Date;
@@ -32,7 +33,6 @@ export type IUserOuput = IUserAttributes;
 class UserModel extends Model<IUserAttributes, IUserInput> implements IUserAttributes {
     public id!: number;
     public keycloak_id!: string;
-    public commercial_use_reason!: string;
     public accepted_terms!: boolean;
     public understand_disclaimer!: boolean;
     public completed_registration!: boolean;
@@ -63,7 +63,8 @@ UserModel.init(
         roles: DataTypes.ARRAY(DataTypes.TEXT),
         affiliation: DataTypes.TEXT,
         portal_usages: DataTypes.ARRAY(DataTypes.TEXT),
-        research_area: DataTypes.TEXT,
+        research_area_description: DataTypes.TEXT,
+        research_areas: DataTypes.ARRAY(DataTypes.TEXT),
         creation_date: {
             type: DataTypes.DATE,
             defaultValue: new Date(),


### PR DESCRIPTION
research_areas : list of string (used in CQDG)
research_area_description : string (used in Include)

Also remove commercial_use_reason as required because it is optional

I choose to keep both fields because we could need both at the same time if we want the user to add details about its research areas and so we don't have to migrate data from a column to the other