### PR TITLE
feat: CQDG-38 add support for different user validator depending on project

### DIFF
--- a/src/db/dal/user.ts
+++ b/src/db/dal/user.ts
@@ -1,7 +1,7 @@
 import createHttpError from 'http-errors';
 import { StatusCodes } from 'http-status-codes';
 
-import { validateUserRegistrationPayload } from '../../utils/userValidator';
+import { UserValidator } from '../../utils/userValidator';
 import UserModel, { IUserInput, IUserOuput } from '../models/User';
 
 const sanitizeInputPayload = (payload: IUserInput) => ({
@@ -85,8 +85,12 @@ export const updateUser = async (keycloak_id: string, payload: IUserInput): Prom
     return results[1][0];
 };
 
-export const completeRegistration = async (keycloak_id: string, payload: IUserInput): Promise<IUserOuput> => {
-    if (!validateUserRegistrationPayload(payload)) {
+export const completeRegistration = async (
+    keycloak_id: string,
+    payload: IUserInput,
+    validator: UserValidator,
+): Promise<IUserOuput> => {
+    if (!validator(payload)) {
         throw createHttpError(
             StatusCodes.BAD_REQUEST,
             'Some required fields are missing to complete user registration',

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
 import { completeRegistration, createUser, getUserById, searchUsers, updateUser } from '../db/dal/user';
+import { keycloakRealm } from '../env';
+import { getUserValidator } from '../utils/userValidator';
 
 // Handles requests made to /users
 const usersRouter = Router();
@@ -51,7 +53,7 @@ usersRouter.put('/', async (req, res, next) => {
 usersRouter.put('/complete-registration', async (req, res, next) => {
     try {
         const keycloak_id = req['kauth']?.grant?.access_token?.content?.sub;
-        const result = await completeRegistration(keycloak_id, req.body);
+        const result = await completeRegistration(keycloak_id, req.body, getUserValidator(keycloakRealm));
         res.status(StatusCodes.OK).send(result);
     } catch (e) {
         next(e);

--- a/src/utils/realm.ts
+++ b/src/utils/realm.ts
@@ -1,0 +1,6 @@
+enum Realm {
+    INCLUDE = 'includedcc',
+    CQDG = 'CQDG',
+}
+
+export default Realm;

--- a/src/utils/userValidator.test.ts
+++ b/src/utils/userValidator.test.ts
@@ -1,0 +1,211 @@
+import { IUserInput } from '../db/models/User';
+import Realm from './realm';
+import { getUserValidator } from './userValidator';
+
+describe('User Validator', () => {
+    describe('getUserValidator', () => {
+        const inputUser: IUserInput = {
+            id: 123,
+            keycloak_id: 'keycloak_id',
+            creation_date: new Date(),
+            updated_date: new Date(),
+            accepted_terms: false,
+            understand_disclaimer: false,
+            completed_registration: false,
+        };
+
+        it('should validate using Include validator if realm = includedcc', () => {
+            const validIncludeInputUser = {
+                ...inputUser,
+                roles: ['role_1'],
+                era_commons_id: 'era_commons_id',
+                portal_usages: ['usage_1'],
+            };
+
+            expect(getUserValidator(Realm.INCLUDE)(validIncludeInputUser)).toBeTruthy();
+
+            const invalidIncludeInputUser = {
+                ...inputUser,
+                roles: ['role_1'],
+                research_areas: ['research_area_1'],
+            };
+
+            expect(getUserValidator(Realm.INCLUDE)(invalidIncludeInputUser)).toBeFalsy();
+        });
+
+        it('should validate using CQDG validator if realm = CQDG', () => {
+            const validCqdgInputUser = {
+                ...inputUser,
+                roles: ['role_1'],
+                research_areas: ['research_area_1'],
+            };
+
+            expect(getUserValidator(Realm.CQDG)(validCqdgInputUser)).toBeTruthy();
+
+            const invalidCqdgInputUser = {
+                ...inputUser,
+                roles: ['role_1'],
+                era_commons_id: 'era_commons_id',
+                portal_usages: ['usage_1'],
+            };
+
+            expect(getUserValidator(Realm.CQDG)(invalidCqdgInputUser)).toBeFalsy();
+        });
+
+        it('should not do extra validation in other cases', () => {
+            expect(getUserValidator('other')(inputUser)).toBeTruthy();
+        });
+    });
+
+    describe('includeUserValidator', () => {
+        it('should return true if roles and portal_usages and an id are not empty', () => {
+            const inputUser: IUserInput = {
+                id: 123,
+                keycloak_id: 'keycloak_id',
+                creation_date: new Date(),
+                updated_date: new Date(),
+                accepted_terms: false,
+                understand_disclaimer: false,
+                completed_registration: false,
+                roles: ['role_1'],
+                portal_usages: ['usage_1'],
+            };
+
+            const userWithEraCommonsId = { ...inputUser, era_commons_id: 'era_commons_id' };
+            const userWithNihNedId = { ...inputUser, nih_ned_id: 'nih_ned_id' };
+            const userWithExternalIds = {
+                ...inputUser,
+                external_individual_fullname: 'external_individual_fullname',
+                external_individual_email: 'external_individual_email',
+            };
+
+            expect(getUserValidator(Realm.INCLUDE)(userWithEraCommonsId)).toBeTruthy();
+            expect(getUserValidator(Realm.INCLUDE)(userWithNihNedId)).toBeTruthy();
+            expect(getUserValidator(Realm.INCLUDE)(userWithExternalIds)).toBeTruthy();
+        });
+
+        it('should return false otherwise', () => {
+            const inputUser: IUserInput = {
+                id: 123,
+                keycloak_id: 'keycloak_id',
+                creation_date: new Date(),
+                updated_date: new Date(),
+                accepted_terms: false,
+                understand_disclaimer: false,
+                completed_registration: false,
+            };
+
+            const inputUserWithoutId = {
+                ...inputUser,
+                roles: ['role_1'],
+                portal_usages: ['usage_1'],
+            };
+
+            const inputUserWithIncompleteExternalIdMissingEmail = {
+                ...inputUser,
+                roles: ['role_1'],
+                portal_usages: ['usage_1'],
+                external_individual_fullname: 'external_individual_fullname',
+            };
+            const inputUserWithIncompleteExternalIdMissingFullname = {
+                ...inputUser,
+                roles: ['role_1'],
+                portal_usages: ['usage_1'],
+                external_individual_email: 'external_individual_email',
+            };
+
+            const inputUserWithEmptyRole = {
+                ...inputUser,
+                roles: [],
+                portal_usages: ['usage_1'],
+            };
+
+            const inputUserWithNullRole = {
+                ...inputUser,
+                roles: null,
+                portal_usages: ['usage_1'],
+            };
+
+            const inputUserWithEmptyPortalUsage = {
+                ...inputUser,
+                roles: ['role_1'],
+                portal_usages: [],
+            };
+
+            const inputUserWithNullPortalUsage = {
+                ...inputUser,
+                roles: ['role_1'],
+                portal_usages: null,
+            };
+
+            expect(getUserValidator(Realm.INCLUDE)(inputUser)).toBeFalsy(); // all are undefined
+            expect(getUserValidator(Realm.INCLUDE)(inputUserWithoutId)).toBeFalsy();
+            expect(getUserValidator(Realm.INCLUDE)(inputUserWithIncompleteExternalIdMissingEmail)).toBeFalsy();
+            expect(getUserValidator(Realm.INCLUDE)(inputUserWithIncompleteExternalIdMissingFullname)).toBeFalsy();
+            expect(getUserValidator(Realm.INCLUDE)(inputUserWithEmptyRole)).toBeFalsy();
+            expect(getUserValidator(Realm.INCLUDE)(inputUserWithNullRole)).toBeFalsy();
+            expect(getUserValidator(Realm.INCLUDE)(inputUserWithEmptyPortalUsage)).toBeFalsy();
+            expect(getUserValidator(Realm.INCLUDE)(inputUserWithNullPortalUsage)).toBeFalsy();
+        });
+    });
+
+    describe('cqdgUserValidator', () => {
+        it('should return true if roles and research_areas are not empty', () => {
+            const validInputUser: IUserInput = {
+                id: 123,
+                keycloak_id: 'keycloak_id',
+                creation_date: new Date(),
+                updated_date: new Date(),
+                accepted_terms: false,
+                understand_disclaimer: false,
+                completed_registration: false,
+                roles: ['role_1'],
+                research_areas: ['research_area_1'],
+            };
+
+            expect(getUserValidator(Realm.CQDG)(validInputUser)).toBeTruthy();
+        });
+
+        it('should return false otherwise', () => {
+            const inputUser: IUserInput = {
+                id: 123,
+                keycloak_id: 'keycloak_id',
+                creation_date: new Date(),
+                updated_date: new Date(),
+                accepted_terms: false,
+                understand_disclaimer: false,
+                completed_registration: false,
+            };
+
+            const inputUserWithEmptyList = {
+                ...inputUser,
+                roles: [],
+                research_areas: [],
+            };
+
+            const inputUserWithNull = {
+                ...inputUser,
+                roles: null,
+                research_areas: null,
+            };
+
+            const inputUserWithOnlyRoles = {
+                ...inputUser,
+                roles: ['role_1'],
+                research_areas: [],
+            };
+
+            const inputUserWithOnlyResearchAreas = {
+                ...inputUser,
+                roles: [],
+                research_areas: ['research_area_1'],
+            };
+
+            expect(getUserValidator(Realm.CQDG)(inputUser)).toBeFalsy(); // both are undefined
+            expect(getUserValidator(Realm.CQDG)(inputUserWithEmptyList)).toBeFalsy();
+            expect(getUserValidator(Realm.CQDG)(inputUserWithNull)).toBeFalsy();
+            expect(getUserValidator(Realm.CQDG)(inputUserWithOnlyRoles)).toBeFalsy();
+            expect(getUserValidator(Realm.CQDG)(inputUserWithOnlyResearchAreas)).toBeFalsy();
+        });
+    });
+});

--- a/src/utils/userValidator.ts
+++ b/src/utils/userValidator.ts
@@ -1,8 +1,31 @@
 import { IUserInput } from '../db/models/User';
+import Realm from './realm';
 
-export const validateUserRegistrationPayload = (payload: IUserInput) =>
+export interface UserValidator {
+    (payload: IUserInput): boolean;
+}
+
+export const getUserValidator = (realm: string): UserValidator => {
+    switch (realm) {
+        case Realm.INCLUDE:
+            return includeUserValidator;
+        case Realm.CQDG:
+            return cqdgUserValidator;
+        default:
+            return defaultUserValidator;
+    }
+};
+
+const includeUserValidator = (payload: IUserInput) =>
     (payload.era_commons_id ||
         payload.nih_ned_id ||
         (payload.external_individual_fullname && payload.external_individual_email)) &&
+    payload.roles &&
     payload.roles.length > 0 &&
+    payload.portal_usages &&
     payload.portal_usages.length > 0;
+
+const cqdgUserValidator = (payload: IUserInput) =>
+    payload.roles && payload.roles.length > 0 && payload.research_areas && payload.research_areas.length > 0;
+
+const defaultUserValidator = (_payload: IUserInput) => true; // no additionnal validation


### PR DESCRIPTION
To be able to have different validators depending on the project (actually the realm in config)

Open to any comment/suggestion, it's just a proposal