### PR TITLE
feat: SJIP-484 add endpoint to reset all consents

### DIFF
--- a/src/db/dal/user.ts
+++ b/src/db/dal/user.ts
@@ -257,7 +257,7 @@ export const completeRegistration = async (
     return results[1][0];
 };
 
-export const resetConsents = async (): Promise<number> => {
+export const resetAllConsents = async (): Promise<number> => {
     const result = await UserModel.update(
         {
             accepted_terms: false,

--- a/src/db/dal/user.ts
+++ b/src/db/dal/user.ts
@@ -257,60 +257,19 @@ export const completeRegistration = async (
     return results[1][0];
 };
 
-export const updateRolesAndDataUsages = async (): Promise<void> => {
-    const results = await UserModel.findAll();
+export const resetConsents = async (): Promise<number> => {
+    const result = await UserModel.update(
+        {
+            accepted_terms: false,
+            understand_disclaimer: false,
+            consent_date: null,
+            updated_date: new Date(),
+        },
+        {
+            where: {},
+            returning: true,
+        },
+    );
 
-    results.map(async (user) => {
-        await UserModel.update(
-            {
-                ...user,
-                updated_date: new Date(),
-                roles: replaceRoles(user.roles || []),
-                portal_usages: replacePortalUsages(user.portal_usages || []),
-            },
-            {
-                where: {
-                    keycloak_id: user.keycloak_id,
-                },
-                returning: true,
-            },
-        );
-    });
+    return result[0];
 };
-
-const replaceRoles = (roles: string[]): string[] =>
-    roles.map((role) => {
-        switch (role.toLocaleLowerCase()) {
-            case 'researcher at an academic or not-for-profit institution':
-                return 'researcher';
-            case 'representative from a for-profit or commercial entity':
-                return 'representative';
-            case 'tool or algorithm developer':
-                return 'developer';
-            case 'community member':
-                return 'community_member';
-            case 'federal employee':
-                return 'federal_employee';
-            default:
-                return role;
-        }
-    });
-
-const replacePortalUsages = (usages: string[]): string[] =>
-    usages.map((usage) => {
-        switch (usage.toLocaleLowerCase()) {
-            case 'learning more about down syndrome and its health outcomes, management, and/or treatment':
-            case 'learn more about down syndrome and its health outcomes, management, and/or treatment':
-                return 'learn_more_about_down_syndrome';
-            case 'helping me design a new research study':
-            case 'help me design a new research study':
-                return 'help_design_new_research_study';
-            case 'identifying datasets that i want to analyze':
-            case 'identify datasets that i want to analyze':
-                return 'identifying_dataset';
-            case 'commercial purposes':
-                return 'commercial_purpose';
-            default:
-                return usage;
-        }
-    });

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
-import { deleteUser, resetConsents } from '../db/dal/user';
+import { deleteUser, resetAllConsents } from '../db/dal/user';
 
 // Handles requests made to /admin
 const adminRouter = Router();
@@ -16,9 +16,9 @@ adminRouter.delete('/deleteUser/:id', async (req, res, next) => {
     }
 });
 
-adminRouter.put('/resetConsents', async (req, res, next) => {
+adminRouter.put('/resetAllConsents', async (req, res, next) => {
     try {
-        const numberOfRowsUpdated = await resetConsents();
+        const numberOfRowsUpdated = await resetAllConsents();
         res.status(StatusCodes.OK).send({ updated: numberOfRowsUpdated });
     } catch (e) {
         next(e);

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
-import { deleteUser } from '../db/dal/user';
+import { deleteUser, resetConsents } from '../db/dal/user';
 
 // Handles requests made to /admin
 const adminRouter = Router();
@@ -11,6 +11,15 @@ adminRouter.delete('/deleteUser/:id', async (req, res, next) => {
         const requestKeycloakId = req.params.id;
         await deleteUser(requestKeycloakId);
         res.status(StatusCodes.OK).send(requestKeycloakId);
+    } catch (e) {
+        next(e);
+    }
+});
+
+adminRouter.put('/resetConsents', async (req, res, next) => {
+    try {
+        const numberOfRowsUpdated = await resetConsents();
+        res.status(StatusCodes.OK).send({ updated: numberOfRowsUpdated });
     } catch (e) {
         next(e);
     }

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -10,7 +10,6 @@ import {
     getProfileImageUploadPresignedUrl,
     getUserById,
     searchUsers,
-    updateRolesAndDataUsages,
     updateUser,
 } from '../db/dal/user';
 import { getUserValidator } from '../utils/userValidator';
@@ -129,16 +128,6 @@ usersRouter.delete('/', async (req, res, next) => {
     try {
         const keycloak_id = req['kauth']?.grant?.access_token?.content?.sub;
         await deleteUser(keycloak_id);
-        res.status(StatusCodes.OK).send({ success: true });
-    } catch (e) {
-        next(e);
-    }
-});
-
-//todo: delete it after INCLUDE roles and data usages migration SJIP-340
-usersRouter.put('/updateRolesAndDataUsages', async (req, res, next) => {
-    try {
-        await updateRolesAndDataUsages();
         res.status(StatusCodes.OK).send({ success: true });
     } catch (e) {
         next(e);


### PR DESCRIPTION
- Ajout d'une route qui reset les consentements de tous les users (role admin nécessaire)

```
accepted_terms: false,
understand_disclaimer: false,
consent_date: null,
updated_date: new Date(),
```

- Suppression de la route updateRolesAndDataUsages qui n'est plus nécessaire