### PR TITLE
feat: SKFP-000 add statistics endpoint to count user created since a date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ COPY --from=build-image ./app/dist ./dist
 COPY package* ./
 COPY migrations ./migrations
 COPY migrateUpWithWrapper.mjs ./migrateUpWithWrapper.mjs
-RUN npm ci --omit=dev
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 && npm ci --omit=dev
 ENV NODE_ENV=production
 CMD [ "npm", "run", "start:prd" ]

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import { adminRoleName } from './config/env';
 import adminRouter from './routes/admin';
 import publicRouter from './routes/public';
 import savedFiltersRouter from './routes/savedFilters';
+import statisticsRouter from './routes/statistics';
 import usersRouter from './routes/user';
 import userSetsRouter from './routes/userSets';
 import { globalErrorHandler, globalErrorLogger } from './utils/errors';
@@ -35,6 +36,7 @@ export default (keycloak: Keycloak): Express => {
     app.use('/saved-filters', keycloak.protect(), savedFiltersRouter);
     app.use('/user-sets', keycloak.protect(), userSetsRouter);
     app.use('/admin', keycloak.protect('realm:' + adminRoleName), adminRouter);
+    app.use('/statistics', keycloak.protect('realm:' + adminRoleName), statisticsRouter);
 
     app.use(globalErrorLogger, globalErrorHandler);
 

--- a/src/db/dal/user.ts
+++ b/src/db/dal/user.ts
@@ -273,3 +273,18 @@ export const resetAllConsents = async (): Promise<number> => {
 
     return result[0];
 };
+
+export const retrieveUserCreatedSince = async (date: string): Promise<number> => {
+    const result = await UserModel.count({
+        where: {
+            [Op.and]: {
+                completed_registration: true,
+                deleted: false,
+                creation_date: {
+                    [Op.gte]: new Date(date),
+                },
+            },
+        },
+    });
+    return result;
+};

--- a/src/routes/statistics.ts
+++ b/src/routes/statistics.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { StatusCodes } from 'http-status-codes';
+
+import { retrieveUserCreatedSince } from '../db/dal/user';
+
+// Handles requests made to /statistics
+const statisticsRouter = Router();
+
+statisticsRouter.get('/createdSince/:year/:month/:day', async (req, res, next) => {
+    try {
+        const year = req.params.year;
+        const month = req.params.month;
+        const day = req.params.day;
+        const result = await retrieveUserCreatedSince(`${year}-${month}-${day}`);
+        res.status(StatusCodes.OK).send({ result });
+    } catch (e) {
+        next(e);
+    }
+});
+
+export default statisticsRouter;


### PR DESCRIPTION
JP a souvent besoin de savoir combien d'utilisateurs ont été créés depuis une certaine date (voir si un évènement en particulier a amener plus de personnes à commencer à utiliser nos portails)
Je commence ce endpoint de statistics accessible uniquement aux admin pour essayer d'automatiser un peu les choses pour qu'il soit plus autonome pour retrouver ces infos

J'ai pas de specs ni rien donc c'est très minimal et on pourra l'augmenter au fil des nouveaux besoins.

Toute suggestion est la bienvenue