### PR TITLE
feat: CQDG-583 add locale column to users table

### DIFF
--- a/migrations/1706287144127_add-users-locale-column.sql
+++ b/migrations/1706287144127_add-users-locale-column.sql
@@ -1,0 +1,7 @@
+-- Up Migration
+ALTER TABLE users 
+    ADD COLUMN locale TEXT;
+
+-- Down Migration
+ALTER TABLE users 
+    DROP COLUMN locale;

--- a/src/config/project/cqdg.ts
+++ b/src/config/project/cqdg.ts
@@ -17,6 +17,7 @@ const cleanedUserAttributes = [
     'affiliation',
     'profile_image_key',
     'research_domains',
+    'locale'
 ];
 
 export const roleOptions = [

--- a/src/config/project/default.ts
+++ b/src/config/project/default.ts
@@ -17,6 +17,7 @@ const cleanedUserAttributes = [
     'affiliation',
     'profile_image_key',
     'research_domains',
+    'locale'
 ];
 
 export const roleOptions = [

--- a/src/config/project/include.ts
+++ b/src/config/project/include.ts
@@ -18,6 +18,7 @@ const cleanedUserAttributes = [
     'profile_image_key',
     'research_domains',
     'research_area_description',
+    'locale'
 ];
 
 const roleOptions = [

--- a/src/db/models/User.ts
+++ b/src/db/models/User.ts
@@ -208,7 +208,7 @@ UserModel.init(
             defaultValue: {},
         },
         locale: {
-            type: DataTypes.STRING(),
+            type: DataTypes.ENUM("en", "fr"),
             validate: {
                 isAlpha: true,
             },

--- a/src/db/models/User.ts
+++ b/src/db/models/User.ts
@@ -30,6 +30,7 @@ interface IUserAttributes {
     completed_registration: boolean;
     deleted: boolean;
     config?: any;
+    locale?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -205,6 +206,12 @@ UserModel.init(
             type: DataTypes.JSONB,
             allowNull: false,
             defaultValue: {},
+        },
+        locale: {
+            type: DataTypes.STRING(),
+            validate: {
+                isAlpha: true,
+            },
         },
     },
     {


### PR DESCRIPTION
add locale column to users table.

This will allow the management of the locale throughout the entire user flow (login/keycloak/in app) in a single and centralised way without having to rely on keycloak token to handle this.