### PR TITLE
feat: CLIN-3239 add resource to filter by flag

### DIFF
--- a/src/db/dal/variant.ts
+++ b/src/db/dal/variant.ts
@@ -24,3 +24,18 @@ export const getEntriesByUniqueIdsAndOrganizations = async function (uniqueIds: 
         }
     });
 }
+
+export const getEntriesByProperties = async function (prop: object, organizationIds: string[]) {
+    return await VariantModel.findAll({
+        attributes: ['unique_id'],
+        group: ['unique_id'],
+        where: {
+            properties: {
+                [Op.contains]: prop
+            },
+            organization_id: {
+                [Op.in]: organizationIds
+            }
+        }
+    });
+}


### PR DESCRIPTION
Resource: `GET` `/variants/filter`

- accepts `flag` param (can be multiple)
- returns array of ids