### PR TITLE
fix: CLIN-3629 discriminate against flags

### DIFF
--- a/src/db/dal/variant.ts
+++ b/src/db/dal/variant.ts
@@ -45,6 +45,11 @@ export const getEntriesByUniqueIdsAndOrganizations = async function (uniqueIds: 
             organization_id: {
                 [Op.in]: organizationIds,
             },
+            properties: {
+                [Op.contains]: {
+                    flags: []
+                }
+            },
         },
     });
 };


### PR DESCRIPTION
Will return entries where properties.flags exists and is an array.

